### PR TITLE
Fix package path in Azure Functions workflow

### DIFF
--- a/.github/workflows/azure-functions-app-java.yml
+++ b/.github/workflows/azure-functions-app-java.yml
@@ -60,6 +60,6 @@ jobs:
       id: fa
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-        package: '${{ env.POM_XML_DIRECTORY }}' # if there are multiple function apps in same project, then this path will be like './${{ env.POM_XML_DIRECTORY }}/target/azure-functions/${{ env.POM_FUNCTIONAPP_NAME }'
+        package: '${{ env.POM_XML_DIRECTORY }}/target/azure-functions/${{ env.AZURE_FUNCTIONAPP_NAME }}' # adjust if your function app is in a different directory
         publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }} # Remove publish-profile to use Azure RBAC
         respect-pom-xml: true


### PR DESCRIPTION
## Summary
- fix the `package` path for the Azure Functions deploy workflow
- clean up comment so YAML is well‑formed

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550e15bdbc8331815cea21c633ec84