### PR TITLE
Update default Java version to 17

### DIFF
--- a/.github/workflows/azure-functions-app-java.yml
+++ b/.github/workflows/azure-functions-app-java.yml
@@ -26,7 +26,7 @@ env:
   AZURE_FUNCTIONAPP_NAME: 'your-app-name'   # set this to your function app name on Azure
   POM_XML_DIRECTORY: '.'                    # set this to the directory which contains pom.xml file
   DISTRIBUTION: 'zulu'                      # set this to the java version to use (e.g. 'zulu', 'temurin', 'microsoft')
-  JAVA_VERSION: '8'                         # set this to the java version to use (e.g. '8', '11', '17')
+  JAVA_VERSION: '17'                        # set this to the java version to use (e.g. '8', '11', '17')
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
- update Java SDK version from 8 to 17 in the Azure Functions workflow

## Testing
- `./mvnw -q test` *(fails: cannot download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6855104edd408331825977b79f3bd20b